### PR TITLE
Issue #136: Missing implementation of core_userlist_provider

### DIFF
--- a/lang/en/jazzquiz.php
+++ b/lang/en/jazzquiz.php
@@ -299,3 +299,5 @@ $string['privacy:metadata:jazzquiz_attempts:responded'] = 'Whether or not the la
 $string['privacy:metadata:jazzquiz_attempts:timestart'] = 'The time that the last question in the attempt was started.';
 $string['privacy:metadata:jazzquiz_attempts:timefinish'] = 'The time that the last question in the attempt was finished.';
 $string['privacy:metadata:jazzquiz_attempts:timemodified'] = 'The time that the last question in the attempt was modified.';
+$string['privacy:metadata:jazzquiz_attendance'] = 'Stores attendance information for JazzQuiz sessions.';
+$string['privacy:metadata:jazzquiz_attendance:userid'] = 'The ID of the user attending the JazzQuiz session.';


### PR DESCRIPTION
Fix for Missing Implementation of core_userlist_provider and Metadata Test Failures

Issue #136: Missing Implementation of core_userlist_provider

The Privacy API provider class for mod_jazzquiz did not implement the core_userlist_provider interface, causing unit test failures.
Added the required methods:
get_users_in_context(userlist $userlist)
delete_data_for_users(userlist $userlist)
These methods now correctly handle user data associated with the plugin's context.
Fix for Metadata Test Failures

Another test failure was identified related to missing metadata for the jazzquiz_attendance table.
The table jazzquiz_attendance contains the userid field, which was not declared in the get_metadata() method of the Privacy API provider.
Metadata for this table has been added, ensuring compliance with Privacy API requirements.